### PR TITLE
syntax correction after contact us section merged

### DIFF
--- a/css/primary.css
+++ b/css/primary.css
@@ -631,6 +631,7 @@ footer {
 		font-size: 0.875em;
 		line-height: 1.3em;
   }
+}
 
 /*End @320px media query */
   


### PR DESCRIPTION
There was a missing closing curly braces at the end of the 320px responsive design section after I merged the contact us section. 